### PR TITLE
Separate metal hdus

### DIFF
--- a/py/absorber.py
+++ b/py/absorber.py
@@ -6,10 +6,14 @@ from . import utils
 class AbsorberData:
 
     #Initialisation function.
-    def __init__(self,name='LYA',rest_wave=utils.lya_rest,flux_transform_m=1.0):
+    def __init__(self,name='LYA',rest_wave=utils.lya_rest,flux_transform_m=1.0,HDU_name=None):
         self.name = name
         self.rest_wave = rest_wave
         self.flux_transform_m = flux_transform_m
+        if HDU_name:
+            self.HDU_name = HDU_name
+        else:
+            self.HDU_name = self.name
 
         # we will store here the optical depth and record when RSDs have been applied
         self.tau = None

--- a/py/absorber_data.py
+++ b/py/absorber_data.py
@@ -11,16 +11,16 @@ def get_lyb_absorber():
 
 def get_metal_dict():
     metal_dict = {
-      'SiII(1260)'  : absorber.AbsorberData('SiII(1260)',  1260.42, 3.542e-4),
-      'SiIII(1207)' : absorber.AbsorberData('SiIII(1207)', 1206.50, 1.8919e-3),
-      'SiII(1193)'  : absorber.AbsorberData('SiII(1193)',  1193.29, 9.0776e-4),
-      'SiII(1190)'  : absorber.AbsorberData('SiII(1190)',  1190.42, 6.4239e-4),
+      'SiII(1260)'  : absorber.AbsorberData('SiII(1260)',  1260.42, 3.542e-4,  'SI1260'),
+      'SiIII(1207)' : absorber.AbsorberData('SiIII(1207)', 1206.50, 1.8919e-3, 'SI1207'),
+      'SiII(1193)'  : absorber.AbsorberData('SiII(1193)',  1193.29, 9.0776e-4, 'SI1193'),
+      'SiII(1190)'  : absorber.AbsorberData('SiII(1190)',  1190.42, 6.4239e-4, 'SI1190'),
       #Until the memory needs are known, the following metals will not be added.
-      #'NV(1243)'    : absorber.AbsorberData('NV(1243)',  1242.804, 5.e-4),
-      #'NV(1239)'    : absorber.AbsorberData('NV(1239)',  1238.821, 5.e-4),
-      #'NI(1200)'    : absorber.AbsorberData('NI(1200)',  1200.,    1.e-3),
-      #'OI(1039)'    : absorber.AbsorberData('OI(1039)',  1039.230, 1.e-3),
-      #'OVI(1038)'   : absorber.AbsorberData('OVI(1038)', 1037.613, 3.382-3),
-      #'OVI(1032)'   : absorber.AbsorberData('OVI(1032)', 1031.912, 5.358e-3),
+      #'NV(1243)'    : absorber.AbsorberData('NV(1243)',  1242.804, 5.e-4,    'N1243'),
+      #'NV(1239)'    : absorber.AbsorberData('NV(1239)',  1238.821, 5.e-4,    'N1239'),
+      #'NI(1200)'    : absorber.AbsorberData('NI(1200)',  1200.,    1.e-3,    'N1200'),
+      #'OI(1039)'    : absorber.AbsorberData('OI(1039)',  1039.230, 1.e-3,    'O1039'),
+      #'OVI(1038)'   : absorber.AbsorberData('OVI(1038)', 1037.613, 3.382-3,  'O1038'),
+      #'OVI(1032)'   : absorber.AbsorberData('OVI(1032)', 1031.912, 5.358e-3, 'O1032'),
     }
     return metal_dict

--- a/py/simulation_data.py
+++ b/py/simulation_data.py
@@ -939,10 +939,10 @@ class SimulationData:
         hdu_METADATA = fits.BinTableHDU.from_columns(cols_METADATA,header=header,name='METADATA')
         hdu_WAVELENGTH = fits.ImageHDU(data=wave_grid,header=header,name='WAVELENGTH')
         #Gives transmission of Lya only
-        hdu_TRANSMISSION = fits.ImageHDU(data=F_grid_Lya,header=header,name='F_LYA')
+        hdu_LYA = fits.ImageHDU(data=F_grid_Lya,header=header,name='F_LYA')
 
         #Combine the HDUs into an HDUlist (including DLAs and metals, if they have been computed)
-        list_hdu = [prihdu, hdu_METADATA, hdu_WAVELENGTH, hdu_TRANSMISSION]
+        list_hdu = [prihdu, hdu_METADATA, hdu_WAVELENGTH, hdu_LYA]
 
         # compute Lyman beta transmission on grid of wavelengths
         if self.lyb_absorber is not None:

--- a/py/simulation_data.py
+++ b/py/simulation_data.py
@@ -923,11 +923,6 @@ class SimulationData:
         # define common wavelength grid to be written in files (in Angstroms)
         wave_grid = np.arange(wave_min,wave_max,wave_step).astype('float32')
 
-        # now we should loop over the different absorbers, combine them and
-        # write them in HDUs. I suggest to have two HDU:
-        # - TRANSMISSION will contain both Lya and Lyb
-        # - METALS will contain all metal absorption
-
         # compute Lyman alpha transmission on grid of wavelengths
         F_grid_Lya = self.compute_grid_transmission(self.lya_absorber,wave_grid).astype('float32')
 
@@ -954,7 +949,7 @@ class SimulationData:
             F_grid_Lyb = self.compute_grid_transmission(self.lyb_absorber,wave_grid).astype('float32')
             list_hdu += [fits.ImageHDU(data=F_grid_Lyb,header=header,name='F_LYB')]
 
-        #Add an HDU for each meatl computed.
+        #Add an HDU for each metal computed.
         if self.metals is not None:
             # compute metals' transmission on grid of wavelengths
             for metal in iter(self.metals.values()):

--- a/scripts/make_transmission.py
+++ b/scripts/make_transmission.py
@@ -123,6 +123,10 @@ parser.add_argument('--transmission-lambda-max', type = float, default = 6500., 
 parser.add_argument('--transmission-delta-lambda', type = float, default = 0.2, required=False,
                     help = 'pixel size of transmission files wavelength grid')
 
+parser.add_argument('--transmission-format', type = str, default = "final", required=False,
+                    choices=['develop','final'],
+                    help = 'format of transmission files')
+
 # TODO: this is now defunct.
 parser.add_argument('--fit-function-to-tuning-data', action="store_true", default = False, required=False,
                     help = 'fit a function of the form A0 * (z^A1) + A2 to the tuning data')
@@ -174,6 +178,7 @@ vel_mult = args.velocity_multiplier
 trans_lmin = args.transmission_lambda_min
 trans_lmax = args.transmission_lambda_max
 trans_dl = args.transmission_delta_lambda
+transmission_format = args.transmission_format
 
 # TODO: print to confirm the arguments. e.g. "DLAs will be added"
 
@@ -316,7 +321,7 @@ gaussian_mean = np.average(means_data_array[:,1],weights=means_data_array[:,0])
 gaussian_variance = np.average(means_data_array[:,2],weights=means_data_array[:,0]) - gaussian_mean**2
 measured_SIGMA_G = np.sqrt(gaussian_variance)
 
-print('\nGaussian skewers have mean {:2.2f}, variance {:2.2f}.'.format(gaussian_mean,measured_SIGMA_G))
+print('\nGaussian skewers have mean {:2.4f}, variance {:2.4f}.'.format(gaussian_mean,measured_SIGMA_G))
 print('\nModifying header showing sigma_G in Gaussian CoLoRe files...')
 
 def modify_header(pixel):
@@ -525,7 +530,7 @@ def produce_final_skewers(base_out_dir,pixel,N_side,zero_mean_delta,lambda_min,m
 
     #transmission
     filename = utils.get_file_name(location,'transmission',N_side,pixel)
-    pixel_object.save_as_transmission(filename,header,overwrite=overwrite,wave_min=trans_lmin,wave_max=trans_lmax,wave_step=trans_dl)
+    pixel_object.save_as_transmission(filename,header,overwrite=overwrite,wave_min=trans_lmin,wave_max=trans_lmax,wave_step=trans_dl,fmt=transmission_format)
 
     if transmission_only == False:
         #Picca tau


### PR DESCRIPTION
Modify the structure of the transmission files to have two options:
 - 'develop': each metal absorber has its own HDU, so can be added separately in quickquasars. Intended to help with tuning of metal absorber strengths
 - 'final': all absorbers are in a single HDU, so that disk space usage is minimised